### PR TITLE
Thread safety in Comms. Small fixes to Pinging system.

### DIFF
--- a/CommProto/include/CommProto/commnode.h
+++ b/CommProto/include/CommProto/commnode.h
@@ -65,9 +65,9 @@ public:
      Polymorphic Destructor.
    */
   virtual ~CommNode() {
-				//May not be thread safe... do we have to lock mutex here?
-				ReplaceSendQueue(nullptr);
-				ReplaceReceiveMap(nullptr);
+    //May not be thread safe... do we have to lock mutex here?
+    ReplaceSendQueue(nullptr);
+    ReplaceReceiveMap(nullptr);
   }
   /**
      Add a packet to the call chain.
@@ -104,12 +104,12 @@ public:
     Replace the Send queue of this node.
   */
   virtual bool ReplaceSendQueue(const Queue<ObjectStream*>* queue) {
-				for (int32_t i = 0; i < send_queue->GetSize(); ++i) {
-						ObjectStream* obj = send_queue->Front();
-						send_queue->Dequeue();
-						free_pointer(obj);
-				}
-				free_pointer(send_queue);
+    for (int32_t i = 0; i < send_queue->GetSize(); ++i) {
+      ObjectStream* obj = send_queue->Front();
+      send_queue->Dequeue();
+      free_pointer(obj);
+    }
+    free_pointer(send_queue);
     send_queue = (Queue<ObjectStream*> *) queue;
     return true;
   }
@@ -118,12 +118,12 @@ public:
     Replace the recv queue of this node.
   */
   virtual bool ReplaceReceiveMap(std::unordered_multimap<uint8_t, AbstractPacket*>* map) {
-				for (auto it = recv_map->begin(); it != recv_map->end(); it++) {
-						AbstractPacket* absPack = it->second;
-						free_pointer(absPack);
-				}
-				free_pointer(recv_map);
-				recv_map = map;
+    for (auto it = recv_map->begin(); it != recv_map->end(); it++) {
+      AbstractPacket* absPack = it->second;
+      free_pointer(absPack);
+    }
+    free_pointer(recv_map);
+    recv_map = map;
     return true;
   }
   /**
@@ -219,7 +219,7 @@ protected:
   /**
     Queue that holds AbstractPacket types for receiving.
   */  
-		std::unordered_multimap <uint8_t, AbstractPacket*>* recv_map;
+  std::unordered_multimap <uint8_t, AbstractPacket*>* recv_map;
   /**
     Queue that holds ObjectStreams used for sending out.
   */

--- a/CommProto/include/CommProto/commnode.h
+++ b/CommProto/include/CommProto/commnode.h
@@ -24,7 +24,6 @@
 #include <CommProto/architecture/connection/transport_type.h>
 #include <CommProto/pkg/packetmanager.h>
 #include <CommProto/tools/data_structures/interface/interface_queue.h>
-#include <unordered_map>
 
 namespace comnet {
 
@@ -65,7 +64,9 @@ public:
      Polymorphic Destructor.
    */
   virtual ~CommNode() {
-    //May not be thread safe... do we have to lock mutex here?
+    /*This is thread-safe but is a bit odd. Perhaps a protected method called
+				DeleteSendQueue and DeleteReceiveQueue can be used by both the ReplaceQueue methods
+				and this destructor*/
     ReplaceSendQueue(nullptr);
     ReplaceReceiveQueue(nullptr);
   }

--- a/CommProto/include/CommProto/comms.h
+++ b/CommProto/include/CommProto/comms.h
@@ -109,9 +109,9 @@ public:
 
  bool Send(AbstractPacket& packet, uint8_t dest_id) override;
 
-	bool ReplaceSendQueue(const Queue<ObjectStream*>* queue) override;
+ bool ReplaceSendQueue(const Queue<ObjectStream*>* queue) override;
 
-	bool ReplaceReceiveMap(std::unordered_multimap<uint8_t, AbstractPacket*>* map);
+ bool ReplaceReceiveMap(std::unordered_multimap<uint8_t, AbstractPacket*>* map);
 
  AbstractPacket* Receive(uint8_t&  source_id) override;
 

--- a/CommProto/include/CommProto/comms.h
+++ b/CommProto/include/CommProto/comms.h
@@ -109,6 +109,10 @@ public:
 
  bool Send(AbstractPacket& packet, uint8_t dest_id) override;
 
+	bool ReplaceSendQueue(const Queue<ObjectStream*>* queue) override;
+
+	bool ReplaceReceiveMap(std::unordered_multimap<uint8_t, AbstractPacket*>* map);
+
  AbstractPacket* Receive(uint8_t&  source_id) override;
 
  /** Method to start communication*/

--- a/CommProto/include/CommProto/comms.h
+++ b/CommProto/include/CommProto/comms.h
@@ -111,7 +111,7 @@ public:
 
  bool ReplaceSendQueue(const Queue<ObjectStream*>* queue) override;
 
- bool ReplaceReceiveMap(std::unordered_multimap<uint8_t, AbstractPacket*>* map);
+ bool ReplaceReceiveQueue(const Queue<std::pair<uint8_t, AbstractPacket*>>* queue);
 
  AbstractPacket* Receive(uint8_t&  source_id) override;
 

--- a/CommProto/include/CommProto/encryption/encryption_interface.h
+++ b/CommProto/include/CommProto/encryption/encryption_interface.h
@@ -50,7 +50,7 @@ public:
   */
   virtual int32_t Decrypt(uint8_t* buffer, uint32_t length, uint8_t iv[BLOCK_SIZE]) = 0;
   /** 
-    Randome numbder generator which fills an array of size legnth
+    Random number generator which fills an array of size length
    */
   virtual uint8_t GenerateRandomIV(uint8_t * buffer, uint32_t length) = 0;
 

--- a/CommProto/include/CommProto/ping/pinger.h
+++ b/CommProto/include/CommProto/ping/pinger.h
@@ -26,7 +26,7 @@
 
 typedef std::chrono::steady_clock Time;
 typedef std::chrono::milliseconds ms;
-typedef std::chrono::steady_clock::time_point TimePoint;// std::chrono::time_point <std::chrono::steady_clock> TimePoint;
+typedef std::chrono::high_resolution_clock::time_point TimePoint;// std::chrono::time_point <std::chrono::steady_clock> TimePoint;
 typedef std::chrono::duration<float> fsec;
 
 namespace comnet {
@@ -73,7 +73,7 @@ public:
     @return The current time.
   */
   static TimePoint GetNow() {
-    return Time::now();    
+    return std::chrono::high_resolution_clock::now();    
   }
 
   /**

--- a/CommProto/include/CommProto/ping/pinger.h
+++ b/CommProto/include/CommProto/ping/pinger.h
@@ -26,7 +26,7 @@
 
 typedef std::chrono::high_resolution_clock Time;
 typedef std::chrono::milliseconds ms;
-typedef std::chrono::system_clock::time_point TimePoint;// std::chrono::time_point <std::chrono::steady_clock> TimePoint;
+typedef std::chrono::steady_clock::time_point TimePoint;// std::chrono::time_point <std::chrono::steady_clock> TimePoint;
 typedef std::chrono::duration<float> fsec;
 
 namespace comnet {

--- a/CommProto/src/comms.cpp
+++ b/CommProto/src/comms.cpp
@@ -45,8 +45,8 @@ void Comms::CommunicationHandlerSend()
      send_mutex.Lock();
      ObjectStream *temp = send_queue->Front();
      send_queue->Dequeue();
-					send_mutex.Unlock();
-					//Send data here
+     send_mutex.Unlock();
+     //Send data here
      conn_layer->Send(temp->header_packet.dest_id, temp->GetBuffer(), temp->GetSize());
      pingManager->ResetSendTime(temp->header_packet.dest_id);
      free_pointer(temp);
@@ -102,8 +102,8 @@ void Comms::CommunicationHandlerRecv() {
             HandlePacket(error, packet);
           } else {
             // store the packet into the Receive queue.
-												CommLock recvLock(recv_mutex);
-												recv_map->emplace(header.source_id, packet);
+            CommLock recvLock(recv_mutex);
+            recv_map->emplace(header.source_id, packet);
           }
         } else {
           debug::Log::Message(debug::LOG_NOTIFY, "Unknown packet recieved.");
@@ -181,13 +181,13 @@ bool Comms::InitConnection(transport_protocol_t conn_type,
     {
       conn_layer = new SerialLink();
       connectionInitialized = conn_layer->InitConnection(port, NULL, baudrate);
-	  break;
+   break;
     }
     case ZIGBEE_LINK:
     {
       conn_layer = new XBeeLink();
       connectionInitialized = conn_layer->InitConnection(port, NULL, baudrate);
-	  break;
+   break;
       // TODO(Garcia): Will need to create throw directives instead.
     }
     default:
@@ -220,7 +220,7 @@ bool Comms::RemoveAddress(uint8_t dest_id)
  if (conn_layer == NULL) return false;
  if (conn_layer->RemoveAddress(dest_id))
  {
-			pingManager->RemovePinger(dest_id);
+   pingManager->RemovePinger(dest_id);
  }
 }
 
@@ -246,39 +246,39 @@ bool Comms::Send(AbstractPacket& packet, uint8_t dest_id) {
     debug::Log::Message(debug::LOG_WARNING, 
                 "Packet was not encrypted! Either encryption was not created, or key was not loaded!");
   }
-		send_mutex.Lock();
+  send_mutex.Lock();
   send_queue->Enqueue(stream);
-		send_mutex.Unlock();
+  send_mutex.Unlock();
   return true;
 }
 
 bool comnet::Comms::ReplaceSendQueue(const Queue<ObjectStream*>* queue)
 {
-		CommLock sendLock(send_mutex);
-		return comnet::CommNode::ReplaceSendQueue(queue);
+  CommLock sendLock(send_mutex);
+  return comnet::CommNode::ReplaceSendQueue(queue);
 }
 
 bool comnet::Comms::ReplaceReceiveMap(std::unordered_multimap<uint8_t, AbstractPacket*>* map)
 {
-		CommLock recvLock(recv_mutex);
-		return comnet::CommNode::ReplaceReceiveMap(map);
+  CommLock recvLock(recv_mutex);
+  return comnet::CommNode::ReplaceReceiveMap(map);
 }
 
 
 AbstractPacket* Comms::Receive(uint8_t&  source_id) {
-		CommLock recvLock(recv_mutex);
-		AbstractPacket* packet = nullptr;
-		if (conn_layer != nullptr && !recv_map->empty()) {
-				// This is a manual Receive function. The user does not need to call this function,
-				// however it SHOULD be used to manually grab a packet from the "orphanage" queue.
-				auto mapIter = recv_map->find(source_id);  //Get the oldest packet from the queue that matches the source_id
-				if (mapIter != recv_map->end())  //True if the iterator is valid
-				{
-					 AbstractPacket* recvPack = mapIter->second;
-						recv_map->erase(mapIter);  //Remove element from the map (other elements with same key should be kept)
-						return recvPack;
-				}
-		}
+  CommLock recvLock(recv_mutex);
+  AbstractPacket* packet = nullptr;
+  if (conn_layer != nullptr && !recv_map->empty()) {
+    // This is a manual Receive function. The user does not need to call this function,
+    // however it SHOULD be used to manually grab a packet from the "orphanage" queue.
+    auto mapIter = recv_map->find(source_id);  //Get the oldest packet from the queue that matches the source_id
+    if (mapIter != recv_map->end())  //True if the iterator is valid
+    {
+      AbstractPacket* recvPack = mapIter->second;
+      recv_map->erase(mapIter);  //Remove element from the map (other elements with same key should be kept)
+      return recvPack;
+    }
+  }
   return NULL;
 }
 

--- a/CommProto/src/comms.cpp
+++ b/CommProto/src/comms.cpp
@@ -102,9 +102,8 @@ void Comms::CommunicationHandlerRecv() {
             HandlePacket(error, packet);
           } else {
             // store the packet into the Receive queue.
-												std::cout << "Added to orphanage" << std::endl;
             CommLock recvLock(recv_mutex);
-												recv_queue->Enqueue(std::make_pair(header.source_id, packet));
+            recv_queue->Enqueue(std::make_pair(header.source_id, packet));
           }
         } else {
           debug::Log::Message(debug::LOG_NOTIFY, "Unknown packet recieved.");
@@ -272,10 +271,10 @@ AbstractPacket* Comms::Receive(uint8_t&  source_id) {
   if (conn_layer != nullptr && !recv_queue->IsEmpty()) {
     // This is a manual Receive function. The user does not need to call this function,
     // however it SHOULD be used to manually grab a packet from the "orphanage" queue.
-				std::pair <uint8_t, AbstractPacket*> queueElm = recv_queue->Front();
-				recv_queue->Dequeue();
-				source_id = queueElm.first;
-				return queueElm.second;
+    std::pair <uint8_t, AbstractPacket*> queueElm = recv_queue->Front();
+    recv_queue->Dequeue();
+    source_id = queueElm.first;
+    return queueElm.second;
   }
   return NULL;
 }

--- a/CommProto/src/encryption/aes_encryption.cpp
+++ b/CommProto/src/encryption/aes_encryption.cpp
@@ -27,7 +27,9 @@
 namespace comnet {
 namespace encryption {
 
-AesEncryption::AesEncryption() :randomGen(0, 255){}
+AesEncryption::AesEncryption() {
+		
+}
 
 AesEncryption::~AesEncryption(){}
 
@@ -94,9 +96,10 @@ int32_t AesEncryption::Decrypt(uint8_t* buffer, uint32_t length, uint8_t iv[BLOC
 }
 
 
-/** Randome numbder generator which fills an array of size legnth*/
+/** Random number generator which fills an array of size length*/
 uint8_t AesEncryption::GenerateRandomIV(uint8_t * buffer, uint32_t length){	
-	for (int x = 0; x < length; x++){
+		static thread_local CommRandom randomGen(RANDOM_GEN_MIN, RANDOM_GEN_MAX);
+		for (int x = 0; x < length; x++){
 		buffer[x] = randomGen.randomUint8();
 	}
 	return 1;

--- a/CommProto/src/encryption/aes_encryption.h
+++ b/CommProto/src/encryption/aes_encryption.h
@@ -32,8 +32,8 @@ namespace encryption {
 class COMM_EXPORT AesEncryption : public EncryptionInterface {
 private:
   CryptoPP::SecByteBlock sec_key;
-		static const int RANDOM_GEN_MIN = 0;
-		static const int RANDOM_GEN_MAX = 255;
+  static const int RANDOM_GEN_MIN = 0;
+  static const int RANDOM_GEN_MAX = 255;
 public:
   AesEncryption();
   ~AesEncryption();

--- a/CommProto/src/encryption/aes_encryption.h
+++ b/CommProto/src/encryption/aes_encryption.h
@@ -32,7 +32,8 @@ namespace encryption {
 class COMM_EXPORT AesEncryption : public EncryptionInterface {
 private:
   CryptoPP::SecByteBlock sec_key;
-  CommRandom randomGen;
+		static const int RANDOM_GEN_MIN = 0;
+		static const int RANDOM_GEN_MAX = 255;
 public:
   AesEncryption();
   ~AesEncryption();

--- a/tests/classes/cpp/udp/main.cpp
+++ b/tests/classes/cpp/udp/main.cpp
@@ -83,8 +83,10 @@ int main(int c, char** args) {
     << comm1.AddAddress(2, "127.0.0.1", 1338)
     << std::endl;
   // CommNode Callback linking.
-  comm1.LinkCallback(new Ping(), new comnet::Callback((comnet::callback_t)PingCallback));
-  comm2.LinkCallback(new Ping(), new comnet::Callback((comnet::callback_t)PingCallback));
+		comm1.AddPacket(new Ping());
+		comm2.AddPacket(new Ping());
+  //comm1.LinkCallback(new Ping(), new comnet::Callback((comnet::callback_t)PingCallback));
+  //comm2.LinkCallback(new Ping(), new comnet::Callback((comnet::callback_t)PingCallback));
 
   // Allow client to suppress or unsuppress messages handled by the CommProtocol Library.
   comnet::debug::Log::Suppress(comnet::debug::LOG_NOTIFY);
@@ -93,16 +95,22 @@ int main(int c, char** args) {
 
   // Test packet.
   Ping bing("I like cats. MEW :3. this is a test...");
+		Ping bing2("I like dogs.");
   // NOTE(All): Be sure to run the nodes! If not, the threads won't execute!
   comm1.Run();
   comm2.Run();
 
   // Loop. To exit, Click the red button on the top left (Windows Visual Studio) OR 
   // CNTRL+C (Linux). 
-  while (true) {
-    std::cout << "Sleeping..." << std::endl;
-    //comm1 will be sending the packet.
-    comm1.Send(bing, 2);
+		comm1.Send(bing, 2);
+		comm1.Send(bing2, 2);
+		while (true) {
+				uint8_t receiveID;
+				ABSPACKET* absPack = (ABSPACKET*)comm2.Receive(receiveID);
+				std::cout << "RUN" << std::endl;
+				if (absPack != nullptr && absPack->GetId() == bing.GetId()) {
+						std::cout << ((Ping*)absPack)->GetCat() << std::endl;
+				}
     std::this_thread::sleep_for(std::chrono::milliseconds(1000));
   }
   std::cin.ignore();

--- a/tests/classes/cpp/udp/main.cpp
+++ b/tests/classes/cpp/udp/main.cpp
@@ -83,10 +83,8 @@ int main(int c, char** args) {
     << comm1.AddAddress(2, "127.0.0.1", 1338)
     << std::endl;
   // CommNode Callback linking.
-		comm1.AddPacket(new Ping());
-		comm2.AddPacket(new Ping());
-  //comm1.LinkCallback(new Ping(), new comnet::Callback((comnet::callback_t)PingCallback));
-  //comm2.LinkCallback(new Ping(), new comnet::Callback((comnet::callback_t)PingCallback));
+  comm1.LinkCallback(new Ping(), new comnet::Callback((comnet::callback_t)PingCallback));
+  comm2.LinkCallback(new Ping(), new comnet::Callback((comnet::callback_t)PingCallback));
 
   // Allow client to suppress or unsuppress messages handled by the CommProtocol Library.
   comnet::debug::Log::Suppress(comnet::debug::LOG_NOTIFY);
@@ -95,22 +93,16 @@ int main(int c, char** args) {
 
   // Test packet.
   Ping bing("I like cats. MEW :3. this is a test...");
-		Ping bing2("I like dogs.");
   // NOTE(All): Be sure to run the nodes! If not, the threads won't execute!
   comm1.Run();
   comm2.Run();
 
   // Loop. To exit, Click the red button on the top left (Windows Visual Studio) OR 
   // CNTRL+C (Linux). 
-		comm1.Send(bing, 2);
-		comm1.Send(bing2, 2);
-		while (true) {
-				uint8_t receiveID;
-				ABSPACKET* absPack = (ABSPACKET*)comm2.Receive(receiveID);
-				std::cout << "RUN" << std::endl;
-				if (absPack != nullptr && absPack->GetId() == bing.GetId()) {
-						std::cout << ((Ping*)absPack)->GetCat() << std::endl;
-				}
+  while (true) {
+    std::cout << "Sleeping..." << std::endl;
+    //comm1 will be sending the packet.
+    comm1.Send(bing, 2);
     std::this_thread::sleep_for(std::chrono::milliseconds(1000));
   }
   std::cin.ignore();


### PR DESCRIPTION
Comms::receive now works. Comms::recv_mutex and Comms::send_mutex are locked only where they need to be (not over the entire receive and send process). Pinger now uses high_resolution_clock.  I think this will work because it is defined as system_clock in VS 2013 and steady_clock in VS 2015 but I'm not sure about GCC.