### PR TITLE
Using log instead of COMMS_DEBUG

### DIFF
--- a/CommProto/include/CommProto/abstractpacket.h
+++ b/CommProto/include/CommProto/abstractpacket.h
@@ -78,8 +78,7 @@ public:
       return dynamic_cast< Type& >( packet );
     } catch ( std::bad_cast e ) {
       // TODO(Garcia): Will require Using a Logger instead of COMMS_DEBUG.
-      COMMS_DEBUG("Bad casting for packet, which is of type %s\n", 
-                  typeid(packet).name());
+      LOG_PRINTF(debug::LOG_ERROR, "Bad casting for packet, which is of type %s\n", typeid(packet).name());
     }
   }
 

--- a/CommProto/include/CommProto/debug/log.h
+++ b/CommProto/include/CommProto/debug/log.h
@@ -39,6 +39,15 @@ enum LogStatus {
   LOG_FATAL     = 0x20,
   LOG_UNKNOWN   = 0x40
 };
+
+#define MAX_LOG_PRINTF_BUFFER_SIZE 100
+
+#define LOG_PRINTF(status, msg, ...) \
+{ \
+	char buffer[MAX_LOG_PRINTF_BUFFER_SIZE];\
+	snprintf(buffer, MAX_LOG_PRINTF_BUFFER_SIZE, msg, ##__VA_ARGS__);\
+	debug::Log::Message(status, std::string(buffer));\
+}
 /**
    Log is a notifier. It provides notifications and determines what should or shouldn't be
    displayed.
@@ -48,16 +57,16 @@ public:
   /**
     Display message to the client.
   */
-  static void Message(LogStatus status, std::string message);
+  static void Message(LogStatus status, const std::string& message);
   /**
     Store message in history.
   */
-  static void StoreMessage(LogStatus status, std::string message);
+  static void StoreMessage(LogStatus status, const std::string& message);
   /**
     Dump all messages currently in history, this will display all messages that 
     were previously stored!
   */
-  static void Dump();
+	static void Dump();
   /** 
     Clear all of the history!
   */

--- a/CommProto/include/CommProto/network/udp.h
+++ b/CommProto/include/CommProto/network/udp.h
@@ -26,7 +26,7 @@
 #include <cstdio>
 #include <cstdlib>
 #include <memory>
-#include <CommProto/debug/comms_debug.h>
+#include <CommProto/debug/log.h>
 
 #define ADDRESS_LENGTH 16
 #define MAX_CONNECTIONS 32

--- a/CommProto/include/CommProto/serialization/objectstream.h
+++ b/CommProto/include/CommProto/serialization/objectstream.h
@@ -22,7 +22,7 @@ along with this program.  If not, see <http://www.gnu.org/licenses/>.
 #include <CommProto/architecture/api.h>
 #include <CommProto/serialization/marshal.h>
 #include <CommProto/serialization/objserializable.h>
-#include <CommProto/debug/comms_debug.h>
+#include <CommProto/debug/log.h>
 #include <CommProto/headerpacket.h>
 #include <unordered_map>
 #include <unordered_set>
@@ -54,9 +54,9 @@ namespace comnet {
 			/** Current postion of streamBuffer and also size of streamBuffer*/
 			int32_t curr_pos;
 			/** Error Handingling methods*/
-			void PrintErrorUnderFlow() { COMMS_DEBUG("\nERROR:\t Source: ObjectStream\t Message: Buffer too small\n"); }
+			void PrintErrorUnderFlow() { debug::Log::Message(debug::LOG_ERROR, "\nERROR:\t Source: ObjectStream\t Message: Buffer too small\n"); }
 			/** Error Handingling methods*/
-			void PrintErrorOverFlow() { COMMS_DEBUG("\nERROR:\t Source: ObjectStream\t Message: Buffer full\n"); }
+			void PrintErrorOverFlow() { debug::Log::Message(debug::LOG_ERROR, "\nERROR:\t Source: ObjectStream\t Message: Buffer full\n"); }
 
 		public:
 

--- a/CommProto/src/architecture/os/os_threads.cpp
+++ b/CommProto/src/architecture/os/os_threads.cpp
@@ -48,7 +48,7 @@ thread_t thread_get_self_id()
 */
 void thread_create(thread_t* thread, void* (*start_routine)(void*), void* arg) 
 {
-  CommProto::debug::Log::Message(debug::"Starting pthread...\n");
+  comnet::debug::Log::Message(comnet::debug::LOG_DEBUG, "Starting pthread...\n");
   pthread_create(thread, NULL, start_routine, arg);
 }
 
@@ -65,13 +65,17 @@ thread_t thread_get_self_id()
 */
 unsigned Sleep(unsigned milliseconds) 
 {
-#if _POSIX_C_SOURCE >= 199309L
-  struct timespec ts;
-  ts.tv_sec = milliseconds / 1000;
-  ts.tv_nsec = (milliseconds * 1000) % 1000000;
-  nanosleep(&ts, NULL);
-#else
-  usleep(milliseconds * 1000);
+#ifdef _POSIX_C_SOURCE
+  if(_POSIX_C_SOURCE >= 199309L) {
+    struct timespec ts;
+    ts.tv_sec = milliseconds / 1000;
+    ts.tv_nsec = (milliseconds * 1000) % 1000000;
+    nanosleep(&ts, NULL);
+  }
+  else
+  {
+    usleep(milliseconds * 1000);
+  }
 #endif // _POSIX_C_SOURCE >= 199309L
 }
 

--- a/CommProto/src/architecture/os/os_threads.cpp
+++ b/CommProto/src/architecture/os/os_threads.cpp
@@ -16,9 +16,8 @@
   You should have received a copy of the GNU General Public License
   along with this program.  If not, see <http://www.gnu.org/licenses/>.
 */
-#define _DEBUG 1
 #include <CommProto/architecture/os/os_threads.h>
-#include <CommProto/debug/comms_debug.h>
+#include <CommProto/debug/log.h>
 
 /*
   Define the target OS. Windows and Unix like systems use different APIs.
@@ -49,7 +48,7 @@ thread_t thread_get_self_id()
 */
 void thread_create(thread_t* thread, void* (*start_routine)(void*), void* arg) 
 {
-  COMMS_DEBUG("Starting pthread...\n");
+  CommProto::debug::Log::Message(debug::"Starting pthread...\n");
   pthread_create(thread, NULL, start_routine, arg);
 }
 

--- a/CommProto/src/comms.cpp
+++ b/CommProto/src/comms.cpp
@@ -70,7 +70,6 @@ void Comms::CommunicationHandlerSend()
     }
     free_pointer(temp);
   }
-  //		COMMS_DEBUG("IM GOING!!\n");
  }
  debug::Log::Message(debug::LOG_DEBUG, "Send Ends!");
 }

--- a/CommProto/src/debug/log.cc
+++ b/CommProto/src/debug/log.cc
@@ -38,7 +38,7 @@ std::vector<std::pair<LogStatus, std::string>> Log::history;
 char Log::suppressed = 0xe;
 
 
-void Log::Message(LogStatus status, std::string message) {
+void Log::Message(LogStatus status, const std::string& message) {
   switch (status) {
     LOG_MESSAGE_CHECK(LOG_DEFAULT, message);
     LOG_MESSAGE_CHECK(LOG_DEBUG, message);
@@ -59,7 +59,7 @@ void Log::ClearHistory() {
 }
 
 
-void Log::StoreMessage(LogStatus status, std::string message) {
+void Log::StoreMessage(LogStatus status, const std::string& message) {
   history.push_back(std::make_pair(status, message));
 }
 

--- a/CommProto/src/encryption/aes_encryption.cpp
+++ b/CommProto/src/encryption/aes_encryption.cpp
@@ -17,7 +17,7 @@
   along with this program.  If not, see <http://www.gnu.org/licenses/>.
 */
 #include <CommProto/architecture/macros.h>
-#include <CommProto/debug/comms_debug.h>
+#include <CommProto/debug/log.h>
 #include <CommProto/headerpacket.h>
 #include <fstream>
 #include <CommProto/encryption/aes_encryption.h>
@@ -41,8 +41,8 @@ uint8_t AesEncryption::LoadKey(char* key){
 		memcpy(&temp_key, key, KEY_LENGTH);//copy key method want byte or constant *byte not char*
 		sec_key = CryptoPP::SecByteBlock(temp_key, KEY_LENGTH);
 	}else{//key lenth too small
-		COMMS_DEBUG("Encryption Key length is too small. AesEncryption::LoadKey(char* key)\n");
-		COMMS_DEBUG("Wanted key size %d read key size of %d\n", KEY_LENGTH, length);
+		debug::Log::Message(debug::LOG_ERROR, "Encryption Key length is too small. AesEncryption::LoadKey(char* key)\n");
+		LOG_PRINTF(debug::LOG_ERROR, "Wanted key size %d read key size of %d\n", KEY_LENGTH, length);
 		return 0;
 	}
 	return 1;//success
@@ -64,12 +64,12 @@ uint8_t AesEncryption::LoadKeyFromFile(char*keyFileName){
 			}
 		}
 		else{//key length is too small
-			COMMS_DEBUG("key.txt characters mismatch.\nCharacters found: %d\nCharacters needed: %d\n", inputString.length(), KEY_LENGTH);
+			LOG_PRINTF(debug::LOG_ERROR, "key.txt characters mismatch.\nCharacters found: %d\nCharacters needed: %d\n", inputString.length(), KEY_LENGTH);
 			return 0;
 		}
 	}
 	else{//file not open	
-		COMMS_DEBUG("%s not found. \n", temp_key);
+		LOG_PRINTF(debug::LOG_ERROR, "%s not found. \n", temp_key);
 		return 0;
 	}
 	keyFileInput.close();

--- a/CommProto/src/network/commxbee.cc
+++ b/CommProto/src/network/commxbee.cc
@@ -18,7 +18,7 @@ along with this program.  If not, see <http://www.gnu.org/licenses/>.
 */
 #include <CommProto/network/commxbee.h>
 //#include <CommProto/network/znodetable.h>
-#include <CommProto/debug/comms_debug.h>
+#include <CommProto/debug/log.h>
 #include <CommProto/architecture/macros.h>
 #include <CommProto/headerpacket.h>
 
@@ -71,7 +71,7 @@ bool CommXBee::AddAddress(uint8_t destId, const char* address64Hex , uint16_t po
  //xbee_conAlloc((con));
 
  if ((ret = xbee_conNew(xbee, &con, "Data", &conAddress)) != XBEE_ENONE) {
-  COMMS_DEBUG("xbee_conNew() node_id: %d  returned: %d", destId, ret);		
+  LOG_PRINTF(debug::LOG_WARNING, "xbee_conNew() node_id: %d  returned: %d", destId, ret);		
   return false;
  }
 
@@ -174,13 +174,13 @@ bool CommXBee::Send(uint8_t destId, uint8_t* txData, uint32_t txLength) {
    offset += size;
 
    xbee_connTx(it->second, NULL, buffer, size + 2);
-   COMMS_DEBUG("Xbee sent data to DestID: %d!\n", destId);
+   LOG_PRINTF(debug::LOG_NOTE, "Xbee sent data to DestID: %d!\n", destId);
    seq++;
   }
   return true;
  }
  
- COMMS_DEBUG("DestID: %d on xbee not found!\n", destId);
+ LOG_PRINTF(debug::LOG_ERROR, "DestID: %d on xbee not found!\n", destId);
  return false;
 }
 
@@ -228,7 +228,7 @@ void CommXBee::stringToAddress(const char* str, uint8_t length, xbee_conAddress 
  }
  else
  {
-  COMMS_DEBUG("Invalid hex to string conversion.\n");
+	 debug::Log::Message(debug::LOG_ERROR, "Invalid hex to string conversion.\n");
   return;
  }
 }

--- a/CommProto/src/network/crc32.cpp
+++ b/CommProto/src/network/crc32.cpp
@@ -18,7 +18,7 @@
 */
 #include <CommProto/network/crc32.h>
 
-#include <CommProto/debug/comms_debug.h>
+#include <CommProto/debug/log.h>
 
 namespace comnet {
 namespace network {
@@ -110,7 +110,7 @@ unsigned int TruncateCrc32(uint8_t* buffer, uint32_t *length){
  if (*length < 4) {
    return -1;
  }
-  COMMS_DEBUG("Truncating CRC.\n");
+ debug::Log::Message(debug::LOG_DEBUG, "Truncating CRC.\n");
  unsigned char a = buffer[--(*length)];
  unsigned char b = buffer[--(*length)];
  unsigned char c = buffer[--(*length)];
@@ -124,7 +124,7 @@ unsigned int TruncateCrc32(uint8_t* buffer, uint32_t *length){
  e = b;
  b = c;
  c = e;
- COMMS_DEBUG("Finished swapping abcd.\n");
+ debug::Log::Message(debug::LOG_DEBUG, "Finished swapping abcd.\n");
 #endif
 
  //store bytes into crc_recv
@@ -133,7 +133,7 @@ unsigned int TruncateCrc32(uint8_t* buffer, uint32_t *length){
  ((char*)&crc_recv)[1] = b;
  ((char*)&crc_recv)[2] = c;
  ((char*)&crc_recv)[3] = d;
- COMMS_DEBUG("truncated CRC...\n");
+ debug::Log::Message(debug::LOG_DEBUG, "truncated CRC...\n");
  //return results
  return crc_recv;
  

--- a/CommProto/src/network/serial.cpp
+++ b/CommProto/src/network/serial.cpp
@@ -284,7 +284,7 @@ UnixRead(Serial& serial, uint8_t* rx_data, uint32_t* rx_len) {
 	debug::Log::Message(debug::LOG_NOTIFY, "\n\nReading serial\n\n");
   int32_t bytes_read = read(h_serial.fd, rx_data, 256);
   if (bytes_read < 0) {
-    debug::Log::Message(debug::LOG_ERROR, "Failed to read from package. erro number %d\n", errno);
+    LOG_PRINTF(debug::LOG_ERROR, "Failed to read from package. erro number %d\n", errno);
   } else {
     *rx_len = bytes_read;
     LOG_PRINTF(debug::LOG_NOTIFY, "**  Recieved\t Length: %d  **\n", bytes_read);

--- a/CommProto/src/network/udp.cpp
+++ b/CommProto/src/network/udp.cpp
@@ -35,17 +35,17 @@ bool UDP::UdpOpen(int* fd)
   /** attempts to open socket 
       returns false if fails*/
   if ((*fd = socket(AF_INET, SOCK_DGRAM, IPPROTO_UDP)) < 0) {
-      COMMS_DEBUG("socket() failed\n");
-      result = false;
+		debug::Log::Message(debug::LOG_ERROR, "socket() failed\n");
+    result = false;
   }
   struct timeval tv;
   // 1 s timeout.
   tv.tv_sec = 1;
   tv.tv_usec = 0;
   if (result && setsockopt(*fd, SOL_SOCKET, SO_RCVTIMEO, (const char *)&tv, sizeof(tv)) == 0) {
-    COMMS_DEBUG("Successful socket option.\n");
+		debug::Log::Message(debug::LOG_NOTIFY, "Successful socket option.\n");
   } else {
-    COMMS_DEBUG("Timeout not set!\nerrno=%d", GET_LAST_ERROR);
+		LOG_PRINTF(debug::LOG_ERROR, "Timeout not set!\nerrno=%d", GET_LAST_ERROR);
     result = false;
   }
   
@@ -106,7 +106,7 @@ bool UDP::InitConnection(const char* port, const char* address)
     // check if port in number
     for (int x = 0; x < length; x++) {
       if (!isdigit(port[x])) {
-        COMMS_DEBUG("initConnection 'port' argument is not a numerical digit for udp connection\n");  
+				debug::Log::Message(debug::LOG_NOTIFY, "initConnection 'port' argument is not a numerical digit for udp connection\n");
         return false;
       }
     }
@@ -122,7 +122,7 @@ bool UDP::InitConnection(const char* port, const char* address)
       
     //bind socket
     if (bind(fd, (struct sockaddr *)&sockaddr.socket_address, sizeof(sockaddr.socket_address)) < 0) {
-      COMMS_DEBUG("bind failed");
+			debug::Log::Message(debug::LOG_ERROR, "bind failed");
 
       return false;
     }
@@ -135,7 +135,7 @@ bool UDP::InitConnection(const char* port, const char* address)
     return true;
   }
 
-  COMMS_DEBUG("Connection failed, error %d\n", GET_LAST_ERROR);
+	LOG_PRINTF(debug::LOG_ERROR, "Connection failed, error %d\n", GET_LAST_ERROR);
   //already connected or failed to open socket
   return false;
 }
@@ -170,10 +170,10 @@ bool UDP::Send(uint8_t* tx_data, uint32_t tx_length)
     int slenSend = sizeof(sockaddr.socket_address);
     if (sendto(fd, (char *) tx_data, tx_length, 0, (struct sockaddr *) &sockaddr.socket_address, slen) < 0)
     {
-      COMMS_DEBUG("sendto() failed. error=%d\n", GET_LAST_ERROR);
+      LOG_PRINTF(debug::LOG_NOTIFY, "sendto() failed. error=%d\n", GET_LAST_ERROR);
       return false;
     } else {	  						
-      COMMS_DEBUG("\n**  Sent\t Length: %d, Port: %d, IP: %s **\n", 
+			LOG_PRINTF(debug::LOG_NOTIFY, "\n**  Sent\t Length: %d, Port: %d, IP: %s **\n",
       tx_length, ntohs(sockaddr.socket_address.sin_port),
       inet_ntoa(sockaddr.socket_address.sin_addr));		  
     }
@@ -197,13 +197,13 @@ bool UDP::Recv(uint8_t* rx_data, uint32_t* rx_length)
                       (struct sockaddr *) &sockaddr.socket_address, 
                       (socklen_t *) &slen);
   } else {
-    COMMS_DEBUG("UDP not connected can't receive\n");
+		debug::Log::Message(debug::LOG_ERROR, "UDP not connected can't receive\n");
     return false;//not connected
   }
   
   if (length < 0) return false;
     
-  COMMS_DEBUG("\n**  Recieved\t Length: %d, Port: %d, IP: %s **\n", 
+	LOG_PRINTF(debug::LOG_NOTIFY, "\n**  Recieved\t Length: %d, Port: %d, IP: %s **\n",
       length, ntohs(sockaddr.socket_address.sin_port), inet_ntoa(sockaddr.socket_address.sin_addr));    
   *rx_length = (uint32_t)length;
 

--- a/CommProto/src/network/xbeelink.cc
+++ b/CommProto/src/network/xbeelink.cc
@@ -19,7 +19,7 @@ along with this program.  If not, see <http://www.gnu.org/licenses/>.
 #include <CommProto/network/xbeelink.h>
 #include <CommProto/network/commxbee.h>
 //#include <CommProto/network/znodetable.h>
-#include <CommProto/debug/comms_debug.h>
+#include <CommProto/debug/log.h>
 #include <CommProto/tools/data_structures/auto_vector.h>
 
 
@@ -44,7 +44,7 @@ XBeeLink::~XBeeLink()
 bool XBeeLink::InitConnection(const char* port, const char* address, uint32_t baudrate) {
   bool success = home->Initialize(port, baudrate);
   if (!success) {
-    COMMS_DEBUG("Home xbee failed to initialize!\n");
+		debug::Log::Message(debug::LOG_NOTIFY, "Home xbee failed to initialize!\n");
   }
   return true;
 }

--- a/CommProto/src/serialization/objectstream.cpp
+++ b/CommProto/src/serialization/objectstream.cpp
@@ -17,7 +17,7 @@ You should have received a copy of the GNU General Public License
 along with this program.  If not, see <http://www.gnu.org/licenses/>.
 */
 #include <CommProto/serialization/objectstream.h>
-#include <CommProto/debug/comms_debug.h>
+#include <CommProto/debug/log.h>
 
 #include <string.h>
 
@@ -80,9 +80,9 @@ ObjectStream& ObjectStream::operator<<(const string_t& data)
  // + 1 for null termination + 1 for storing length of string as byte
  if (curr_pos + strLen + 2 < MAX_PACKET_SIZE)
  {
-         //COMMS_DEBUG("STRING BEFORE: %d\n", currentPostion);
+  //LOG_PRINTF(debug::LOG_DEBUG, "STRING BEFORE: %d\n", curr_pos);
   curr_pos += PackString(data, strLen, stream_buffer + curr_pos);
-  //COMMS_DEBUG("STRING AFTER: %d\n", currentPostion);
+  //LOG_PRINTF(debug::LOG_DEBUG, "STRING AFTER: %d\n", curr_pos);
  }
  else
  {
@@ -100,9 +100,9 @@ ObjectStream& ObjectStream::operator<<(const std::wstring& data)
  // + 2 for null termination + 1 for storing length of string as byte
  if (curr_pos + strLen + 2 < MAX_PACKET_SIZE)
  {
-   COMMS_DEBUG("SIZE BEFORE: %d\n", curr_pos);
+   //LOG_PRINTF(debug::LOG_DEBUG, "SIZE BEFORE: %d\n", curr_pos);
    curr_pos += PackWideString(data,strLen, stream_buffer + curr_pos);
-   COMMS_DEBUG("SIZE AFTER: %d\n", curr_pos);
+	 //LOG_PRINTF(debug::LOG_DEBUG, "SIZE AFTER: %d\n", curr_pos);
  }
  else
  {


### PR DESCRIPTION
COMMS_DEBUG is still there but all calls previously made to it have been replaced with Log::Message or LOG_PRINTF.